### PR TITLE
103 sipm events

### DIFF
--- a/G4SOLAr/include/analysis/SLArUserPhotonTrackInformation.hh
+++ b/G4SOLAr/include/analysis/SLArUserPhotonTrackInformation.hh
@@ -28,8 +28,8 @@ enum SLArTrackStatus { active=1, hitPMT=2, absorbed=4, boundaryAbsorbed=8,
 */
 
 namespace optical {
-  enum EPhotonCreator {kUnknown = 0, kCherenkov = 1, kScintillation = 2, kWLS= 3, kOther = 4};
-  inline G4String EPhProcName[5] = {"Unknown", "Cherenkov", "Scintillation", "WLS", "Other"};
+  enum EPhotonCreator {kUnknown = 0, kCherenkov = 1, kScintillation = 2, kWLS= 3, kPrimaryGen = 4, kOther = 4};
+  inline G4String EPhProcName[6] = {"Unknown", "Cherenkov", "Scintillation", "WLS", "PriamryGen", "Other"};
 }
 
 class SLArUserPhotonTrackInformation : public G4VUserTrackInformation

--- a/G4SOLAr/include/event/SLArEventAnode.hh
+++ b/G4SOLAr/include/event/SLArEventAnode.hh
@@ -27,7 +27,7 @@ class SLArEventAnode : public TNamed {
     inline int GetNhits() const {return fNhits;}
     inline bool IsActive() const {return fIsActive;}
 
-    SLArEventTile& RegisterHit(const SLArEventPhotonHit& hit, int mt_idx = -999, int t_idx = -999); 
+    SLArEventSiPM& RegisterHit(const SLArEventPhotonHit& hit, int mt_idx = -999, int t_idx = -999); 
     SLArEventChargePixel& RegisterChargeHit(const SLArCfgAnode::SLArPixIdx& pixId, const SLArEventChargeHit& hit); 
     int ResetHits(); 
     int SoftResetHits();
@@ -57,7 +57,7 @@ class SLArEventAnode : public TNamed {
     std::map<int, SLArEventMegatile> fMegaTilesMap;
 
   public:
-    ClassDef(SLArEventAnode, 2)
+    ClassDef(SLArEventAnode, 3)
 };
 
 class SLArListEventAnode: public TObject {

--- a/G4SOLAr/include/event/SLArEventHitsCollection.hh
+++ b/G4SOLAr/include/event/SLArEventHitsCollection.hh
@@ -35,7 +35,7 @@ class SLArEventHitsCollection : public TNamed {
     inline UShort_t GetClockUnit() const {return fClockUnit;}
     inline int GetIdx() const {return fIdx;}
     inline int GetNhits() const {return fNhits;}
-    inline virtual double GetTime() {return -1.;} 
+    inline virtual double GetTime() const {return -1.;} 
     inline HitsCollection_t& GetHits() {return fHits;}
     inline const HitsCollection_t& GetConstHits() const {return fHits;}
     inline BacktrackerVectorCollection_t& GetBacktrackerRecordCollection() {return fBacktrackerCollections;}

--- a/G4SOLAr/include/event/SLArEventPhotonHit.hh
+++ b/G4SOLAr/include/event/SLArEventPhotonHit.hh
@@ -10,10 +10,10 @@
 
 #include "event/SLArEventGenericHit.hh"
 
-enum  EPhProcess {kAll = 0, kCher = 1, kScnt = 2, kWLS = 3, kOther = 4};
+enum  EPhProcess {kAll = 0, kCher = 1, kScnt = 2, kWLS = 3, kPrimaryGen = 4, kOther = 5};
 
-inline TString EPhProcName[5] = {"All", "Cher"     , "Scint"        , "WLS", "Other"};
-inline TString EPhProcTitle[5]= {"All", "Cherenkov", "Scintillation", "WLS", "Other"};
+inline TString EPhProcName[6] = {"All", "Cher"     , "Scint"        , "WLS", "PrimaryGen", "Other"};
+inline TString EPhProcTitle[6]= {"All", "Cherenkov", "Scintillation", "WLS", "PrimaryGen", "Other"};
 
 class SLArEventPhotonHit : public SLArEventGenericHit  
 {

--- a/G4SOLAr/include/event/SLArEventReadoutLinkDef.h
+++ b/G4SOLAr/include/event/SLArEventReadoutLinkDef.h
@@ -26,7 +26,9 @@
 #pragma link C++ class SLArEventHitsCollection<SLArEventPhotonHit>+;
 #pragma link C++ class SLArEventHitsCollection<SLArEventChargeHit>+;
 #pragma link C++ class SLArEventChargePixel+; 
+#pragma link C++ class SLArEventSiPM+; 
 #pragma link C++ class std::map<int, SLArEventChargePixel>+; 
+#pragma link C++ class std::map<int, SLArEventSiPM>+; 
 #pragma link C++ class SLArEventTile+;
 #pragma link C++ class std::map<int, SLArEventTile>+;
 #pragma link C++ class SLArEventMegatile+;

--- a/G4SOLAr/include/event/SLArEventSiPM.hh
+++ b/G4SOLAr/include/event/SLArEventSiPM.hh
@@ -1,0 +1,52 @@
+/**
+ * @author      : Daniele Guffanti (daniele.guffanti@mib.infn.it)
+ * @file        : SLArEventSiPM
+ * @created     : Thursday Apr 17, 2025 17:00:35 CEST
+ */
+
+#ifndef SLAREVENTSIPM_HH
+
+#define SLAREVENTSIPM_HH
+
+#include "event/SLArEventHitsCollection.hh"
+#include "event/SLArEventPhotonHit.hh"
+
+class SLArEventSiPM : public SLArEventHitsCollection<SLArEventPhotonHit> {
+  public: 
+    inline SLArEventSiPM() : SLArEventHitsCollection<SLArEventPhotonHit>() {
+      fClockUnit = 1;
+    } 
+
+    inline SLArEventSiPM(const int& idx) 
+      : SLArEventHitsCollection<SLArEventPhotonHit>(idx) 
+    {
+      fName = Form("EvSiPM%i", fIdx); 
+      fClockUnit = 1; 
+    }
+
+    inline SLArEventSiPM(const int& idx, const SLArEventPhotonHit& hit) 
+      : SLArEventSiPM(idx) 
+    {
+      RegisterHit(hit); 
+    }
+
+    inline SLArEventSiPM(const SLArEventSiPM& right) 
+      : SLArEventHitsCollection<SLArEventPhotonHit>(right) 
+    {}
+
+    inline double GetTime() const {
+      if (fHits.empty()) return -999.;
+
+      return (fHits.begin()->first * fClockUnit);
+    }
+
+  private: 
+
+  public: 
+    ClassDef(SLArEventSiPM, 1)
+};
+
+
+
+#endif /* end of include guard SLAREVENTSIPM_HH */
+

--- a/G4SOLAr/include/event/SLArEventTile.hh
+++ b/G4SOLAr/include/event/SLArEventTile.hh
@@ -8,15 +8,11 @@
 
 #define SLAREVENTTILE_HH
 
-#include <iostream>
-#include <vector>
 #include <map>
-#include <memory>
-#include "event/SLArEventHitsCollection.hh"
+#include "event/SLArEventSiPM.hh"
 #include "event/SLArEventChargePixel.hh"
-#include "event/SLArEventPhotonHit.hh"
 
-class SLArEventTile :  public SLArEventHitsCollection<SLArEventPhotonHit> 
+class SLArEventTile :  public TNamed 
 {
   public: 
     SLArEventTile(); 
@@ -25,27 +21,39 @@ class SLArEventTile :  public SLArEventHitsCollection<SLArEventPhotonHit>
     ~SLArEventTile(); 
 
     double GetTime() const;
-    double GetTime(EPhProcess proc) const;
     inline std::map<int, SLArEventChargePixel>& GetPixelEvents() {return fPixelHits;}
     inline const std::map<int, SLArEventChargePixel>& GetConstPixelEvents() const {return fPixelHits;}
     inline double GetNPixelHits() const {return fPixelHits.size();}
+    inline std::map<int, SLArEventSiPM>& GetSiPMEvents() {return fSiPMHits;}
+    inline const std::map<int, SLArEventSiPM>& GetConstSiPMEvents() const {return fSiPMHits;}
+    inline double GetNSiPMHits() const {return fSiPMHits.size();}
     double GetPixelHits() const; 
+    int GetSiPMHits() const;
     inline void SetChargeBacktrackerRecordSize(const UShort_t size) {fChargeBacktrackerRecordSize = size;}
     inline UShort_t GetChargeBacktrackerRecordSize() const {return fChargeBacktrackerRecordSize;}
+    inline void SetSiPMBacktrackerRecordSize(const UShort_t size) {fSiPMBacktrackerRecordSize = size;}
+    inline UShort_t GetSiPMBacktrackerRecordSize() const {return fSiPMBacktrackerRecordSize;}   
     void PrintHits() const; 
     SLArEventChargePixel& RegisterChargeHit(const int&, const SLArEventChargeHit& ); 
+    SLArEventSiPM& RegisterSiPMHit(const int&, const SLArEventPhotonHit& );
+    SLArEventSiPM& RegisterSiPMHit(const SLArEventPhotonHit& );
     int ResetHits(); 
-    int SoftResetHits();
+    inline void SetActive(bool is_active) {fIsActive = is_active;}
+    //int SoftResetHits();
 
     //bool SortHits(); 
     //bool SortPixelHits();
 
   protected:
+    int fIdx;
+    bool fIsActive;
     UShort_t fChargeBacktrackerRecordSize;
+    UShort_t fSiPMBacktrackerRecordSize;
     std::map<int, SLArEventChargePixel> fPixelHits; 
+    std::map<int, SLArEventSiPM> fSiPMHits;
 
   public:
-     ClassDef(SLArEventTile, 2)
+     ClassDef(SLArEventTile, 3)
 };
 
 #endif /* end of include guard SLAREVENTTILE_HH */

--- a/G4SOLAr/src/action/SLArEventAction.cc
+++ b/G4SOLAr/src/action/SLArEventAction.cc
@@ -301,7 +301,7 @@ G4int SLArEventAction::RecordEventReadoutTile(const G4Event* ev, const G4int& ve
       dstHit.SetCellNr( sipm_nr );
 
       auto& ev_anode = SLArAnaMgr->GetEventAnode().GetEventAnodeByID(anode_idx);
-      auto& ev_tile = ev_anode.RegisterHit(dstHit, mtIdx, tIdx);
+      auto& ev_sipm = ev_anode.RegisterHit(dstHit, mtIdx, tIdx);
       
 #ifdef SLAR_DEBUG
       G4cout << "SLArEventAction::RecordEventReadoutTile() hit nr " << i << G4endl;
@@ -317,7 +317,7 @@ G4int SLArEventAction::RecordEventReadoutTile(const G4Event* ev, const G4int& ve
       if (bktManager) {
         if (bktManager->IsNull() == false) {
           auto& records = 
-            ev_tile.GetBacktrackerVector( ev_tile.ConvertToClock(dstHit.GetTime()) );
+            ev_sipm.GetBacktrackerVector( ev_sipm.ConvertToClock(dstHit.GetTime()) );
 
           for (size_t ib = 0; ib < bktManager->GetBacktrackers().size(); ib++) {
             bktManager->GetBacktrackers().at(ib)->Eval(&dstHit, 

--- a/G4SOLAr/src/action/SLArStackingAction.cc
+++ b/G4SOLAr/src/action/SLArStackingAction.cc
@@ -192,6 +192,7 @@ SLArStackingAction::ClassifyNewTrackOpticalPhoton(const G4Track* aTrack) const
   if (aTrack->GetParentID() == 0) {
     //fEventAction->RegisterNewTrackPID(aTrack->GetTrackID(), aTrack->GetTrackID()); 
     photonInfo->SetAncestorID(aTrack->GetTrackID());
+    photonInfo->SetCreator( optical::kPrimaryGen );
     UpdatePrimaryTrackID(aTrack, anaMngr);
     aTrack->SetUserInformation(photonInfo);
     return kClassification;

--- a/G4SOLAr/src/analysis/SensitiveDetectors/SLArReadoutTileSD.cc
+++ b/G4SOLAr/src/analysis/SensitiveDetectors/SLArReadoutTileSD.cc
@@ -100,7 +100,7 @@ G4bool SLArReadoutTileSD::ProcessHits_constStep(const G4Step* step,
   const auto photonInfo = 
     dynamic_cast<const SLArUserPhotonTrackInformation*>
     (track->GetUserInformation());
-  G4int procID = (photonInfo) ? photonInfo->GetCreator() : optical::kUnknown;
+  G4int procID = (photonInfo) ? photonInfo->GetCreator() : optical::kOther;
   G4int origin_vol_id = (photonInfo) ? photonInfo->GetOriginVolumID() : -1;
  
   SLArReadoutTileHit* hit = nullptr;

--- a/G4SOLAr/src/event/CMakeLists.txt
+++ b/G4SOLAr/src/event/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SLAR_EVT_HITS_HEADERS
   "${SLAR_EVT_INCLUDE_DIR}/SLArEventBacktrackerRecord.hh"
   "${SLAR_EVT_INCLUDE_DIR}/SLArEventHitsCollection.hh"
   "${SLAR_EVT_INCLUDE_DIR}/SLArEventChargePixel.hh"
+  "${SLAR_EVT_INCLUDE_DIR}/SLArEventSiPM.hh"
   "${SLAR_EVT_INCLUDE_DIR}/SLArEventTile.hh"
   "${SLAR_EVT_INCLUDE_DIR}/SLArEventMegatile.hh"
   "${SLAR_EVT_INCLUDE_DIR}/SLArEventAnode.hh"

--- a/G4SOLAr/src/event/SLArEventAnode.cc
+++ b/G4SOLAr/src/event/SLArEventAnode.cc
@@ -78,18 +78,13 @@ SLArEventMegatile& SLArEventAnode::GetOrCreateEventMegatile(const int mtIdx) {
   }
 }
 
-SLArEventTile& SLArEventAnode::RegisterHit(const SLArEventPhotonHit& hit, int mgtile_idx, int tile_idx) {
+SLArEventSiPM& SLArEventAnode::RegisterHit(const SLArEventPhotonHit& hit, int mgtile_idx, int tile_idx) {
   if (mgtile_idx < 0) mgtile_idx = hit.GetMegaTileID(); 
   if (tile_idx < 0) tile_idx = hit.GetTileID(); 
   auto& mt_event = GetOrCreateEventMegatile(mgtile_idx);
-  auto& t_event = mt_event.RegisterHit(hit, tile_idx);
-  return t_event;
-  //} else {
-    //printf("SLArEventAnode::RegisterHit WARNING\n"); 
-    //printf("Megatile with ID %i is not in store\n", mgtile_idx); 
-    //CreateEventMegatile(hit->GetMegaTileIdx());
-    //return 0; 
-  //}
+  auto& t_event = mt_event.GetOrCreateEventTile(tile_idx);
+  auto& sipm_event = t_event.RegisterSiPMHit(hit);
+  return sipm_event;
 }
 
 SLArEventChargePixel& SLArEventAnode::RegisterChargeHit(const SLArCfgAnode::SLArPixIdx& pixIdx, const SLArEventChargeHit& hit) {

--- a/G4SOLAr/src/event/SLArEventMegatile.cc
+++ b/G4SOLAr/src/event/SLArEventMegatile.cc
@@ -41,7 +41,7 @@ SLArEventMegatile::SLArEventMegatile(const SLArCfgMegaTile* cfg)
 int SLArEventMegatile::ResetHits() {
   int nhits = 0;
   for (auto &tile : fTilesMap) {
-    nhits += tile.second.GetNhits(); 
+    nhits += tile.second.GetNSiPMHits(); 
     tile.second.ResetHits(); 
     //delete tile.second;
   }
@@ -80,7 +80,7 @@ SLArEventTile& SLArEventMegatile::GetOrCreateEventTile(const int& tileId)
   else {
     fTilesMap.insert( std::make_pair(tileId, SLArEventTile(tileId) ) );  
     auto& t_event = fTilesMap[tileId];
-    t_event.SetBacktrackerRecordSize( fLightBacktrackerRecordSize ); 
+    t_event.SetSiPMBacktrackerRecordSize( fLightBacktrackerRecordSize ); 
     t_event.SetChargeBacktrackerRecordSize( fChargeBacktrackerRecordSize ); 
     return t_event;
   }
@@ -96,14 +96,14 @@ SLArEventTile& SLArEventMegatile::RegisterHit(const SLArEventPhotonHit& hit, con
   fNhits++; 
   
   auto& tile_ev = GetOrCreateEventTile(tile_idx);
-  tile_ev.RegisterHit(hit);
+  tile_ev.RegisterSiPMHit(hit);
   return tile_ev;
 }
 
 int SLArEventMegatile::GetNPhotonHits() const {
   int nhits = 0;
   for (const auto &tile : fTilesMap) {
-    nhits += tile.second.GetNhits(); 
+    nhits += tile.second.GetNSiPMHits();
   }
 
   return nhits; 

--- a/G4SOLAr/src/event/SLArEventPhotonHit.cc
+++ b/G4SOLAr/src/event/SLArEventPhotonHit.cc
@@ -34,7 +34,8 @@ SLArEventPhotonHit::SLArEventPhotonHit(float time, int proc, float wvl)
   if      (proc == 1) fProcess = kCher;
   else if (proc == 2) fProcess = kScnt;
   else if (proc == 3) fProcess = kWLS ; 
-  else                fProcess = kAll ;
+  else if (proc == 4) fProcess = kPrimaryGen; 
+  else                fProcess = kOther;
 }
 
 SLArEventPhotonHit::SLArEventPhotonHit(const SLArEventPhotonHit &pmtHit) 

--- a/SOLArUtils/source/src/SLArEveDisplay.cc
+++ b/SOLArUtils/source/src/SLArEveDisplay.cc
@@ -411,11 +411,11 @@ namespace display {
         const auto& idx_t = ev_t_itr.first;
         const auto& ev_t = ev_t_itr.second;
 
-        if (ev_t.GetNhits() == 0) continue;
+        if (ev_t.GetNSiPMHits() == 0) continue;
 
         auto& cfg_t = cfg_mt.GetBaseElement(idx_t); 
 
-        int nhit = ev_t.GetNhits();
+        int nhit = ev_t.GetNSiPMHits();
         if (nhit > nhit_max) nhit_max = nhit;
 
         const ROOT::Math::XYZVectorD t_pos = {cfg_t.GetPhysX(), cfg_t.GetPhysY(), cfg_t.GetPhysZ() }; 


### PR DESCRIPTION
Restructure the event tile design to store independent SiPM events. 
It is then possible to separate the scintillation/wls origin of optical ph hits at the single SiPM level