### PR TITLE
Distribute ionizationi charge generaion along the step

### DIFF
--- a/G4SOLAr/include/analysis/SLArAnalysisManagerMsgr.hh
+++ b/G4SOLAr/include/analysis/SLArAnalysisManagerMsgr.hh
@@ -55,7 +55,6 @@ class SLArAnalysisManagerMsgr : public G4UImessenger
     G4UIcmdWithAString*         fCmdEnableBacktracker;
     G4UIcmdWithAString*         fCmdRegisterBacktracker;
     G4UIcmdWithAnInteger*       fCmdSetZeroSuppressionThrs;
-    G4UIcmdWithADoubleAndUnit*  fCmdElectronLifetime; 
     G4UIcmdWithADoubleAndUnit*  fCmdXSecEMin;
     G4UIcmdWithADoubleAndUnit*  fCmdXSecEMax;
     G4UIcmdWithAnInteger*       fCmdXSecNPoints;

--- a/G4SOLAr/include/physics/LiquidArgon/SLArLArProperties.hh
+++ b/G4SOLAr/include/physics/LiquidArgon/SLArLArProperties.hh
@@ -22,7 +22,7 @@ class SLArLArProperties {
     inline G4double GetElectronLifetime() const {return fElectronLifetime;}
 
     void SetElectricField(double _E) {fElectricField = _E;}
-    inline void SetElectronLifetime(double lt) { fElectronLifetime = lt; }
+    inline void SetElectronLifetime(double lt) { fElectronLifetime = lt; fElectronLifetimeInverse = 1.0/lt; }
     void ComputeProperties(); 
     void PrintProperties() const; 
 
@@ -33,7 +33,9 @@ class SLArLArProperties {
     double fDiffCoefficientL;    //!< Longitudinal Diffusion Coefficient
     double fDiffCoefficientT;    //!< Transverse Diffusion Coefficient
     double fvDrift;              //!< Electron drift velocity
+    double fvDriftInverse;       //!< Inverse of drift velocity, for fast computation of drift time
     double fElectronLifetime;    //!< Electron lifetime 
+    double fElectronLifetimeInverse; //!< Inverse of electron lifetime, for fast computation of survival fraction
 
     double ComputeMobility(double E, double larT);
     double ComputeMobility(std::array<double, 2> par); 

--- a/G4SOLAr/include/physics/LiquidArgon/SLArLArProperties.hh
+++ b/G4SOLAr/include/physics/LiquidArgon/SLArLArProperties.hh
@@ -10,6 +10,7 @@
 
 #include <array>
 #include <G4ThreeVector.hh>
+#include <G4SystemOfUnits.hh>
 
 class SLArLArProperties {
   public: 
@@ -24,11 +25,56 @@ class SLArLArProperties {
     inline double GetSegmentLength() const {return fLSegment;}
     inline unsigned int GetNSegmentsLimit() const {return fNSegmentsLimit;}
 
-    inline void SetElectricField(double _E) {fElectricField = _E;}
-    inline void SetElectronLifetime(double lt) { fElectronLifetime = lt; fElectronLifetimeInverse = 1.0/lt; }
-    inline void SetStepLengthThreshold(double step_threshold) {fStepThreshold = step_threshold;}
-    inline void SetSegmentLength(double segment_length) {fLSegment = segment_length;}
-    inline void SetNSegmentsLimit(unsigned int n_segments_limit) {fNSegmentsLimit = n_segments_limit;}
+    inline void SetElectricField(double _E)
+    {
+      if (_E <= 0.0) {
+        G4ExceptionDescription ed;
+        ed << "Invalid electric field: " << _E << " V/cm. Resetting to 0.5 kV/cm.";
+        G4Exception("SLArLArProperties::SetElectricField", "InvalidElectricField", JustWarning, ed);
+        _E = 500*CLHEP::volt/CLHEP::cm; 
+      }
+      fElectricField = _E;
+    }
+    inline void SetElectronLifetime(double lt) 
+    { 
+      if (lt <= 0.0) {
+        G4ExceptionDescription ed;
+        ed << "Invalid electron lifetime: " << lt << ". Resetting to 1e-7 s.";
+        G4Exception("SLArLArProperties::SetElectronLifetime", "InvalidElectronLifetime", JustWarning, ed);
+        lt = 1e-7; 
+      }
+      fElectronLifetime = lt; fElectronLifetimeInverse = 1.0/lt; 
+    }
+    inline void SetStepLengthThreshold(double step_threshold) 
+    {
+      if (step_threshold <= 0.0) {
+        G4ExceptionDescription ed;
+        ed << "Invalid step length threshold: " << step_threshold << ". Resetting to 1 mm.";
+        G4Exception("SLArLArProperties::SetStepLengthThreshold", "InvalidStepThreshold", JustWarning, ed);
+        step_threshold = 1.0*CLHEP::mm; 
+      }
+      fStepThreshold = step_threshold;
+    }
+    inline void SetSegmentLength(double segment_length)
+    {
+      if (segment_length <= 0.0) {
+        G4ExceptionDescription ed;
+        ed << "Invalid segment length: " << segment_length << ". Resetting to 0.5 mm.";
+        G4Exception("SLArLArProperties::SetSegmentLength", "InvalidSegmentLength", JustWarning, ed);
+        segment_length = 0.5*CLHEP::mm; 
+      }
+      fLSegment = segment_length;
+    }
+    inline void SetNSegmentsLimit(unsigned int n_segments_limit)
+    {
+      if (n_segments_limit < 1) {
+        G4ExceptionDescription ed;
+        ed << "Invalid number of segments limit: " << n_segments_limit << ". Resetting to 1.";
+        G4Exception("SLArLArProperties::SetNSegmentsLimit", "InvalidSegmentLimit", JustWarning, ed);
+        n_segments_limit = 1;
+      }
+      fNSegmentsLimit = n_segments_limit;
+    }
 
     void ComputeProperties(); 
     void PrintProperties() const; 

--- a/G4SOLAr/include/physics/LiquidArgon/SLArLArProperties.hh
+++ b/G4SOLAr/include/physics/LiquidArgon/SLArLArProperties.hh
@@ -20,9 +20,16 @@ class SLArLArProperties {
 
     inline G4double GetElectricField() const {return fElectricField;}
     inline G4double GetElectronLifetime() const {return fElectronLifetime;}
+    inline double GetStepLengthThreshold() const {return fStepThreshold;}
+    inline double GetSegmentLength() const {return fLSegment;}
+    inline unsigned int GetNSegmentsLimit() const {return fNSegmentsLimit;}
 
-    void SetElectricField(double _E) {fElectricField = _E;}
+    inline void SetElectricField(double _E) {fElectricField = _E;}
     inline void SetElectronLifetime(double lt) { fElectronLifetime = lt; fElectronLifetimeInverse = 1.0/lt; }
+    inline void SetStepLengthThreshold(double step_threshold) {fStepThreshold = step_threshold;}
+    inline void SetSegmentLength(double segment_length) {fLSegment = segment_length;}
+    inline void SetNSegmentsLimit(unsigned int n_segments_limit) {fNSegmentsLimit = n_segments_limit;}
+
     void ComputeProperties(); 
     void PrintProperties() const; 
 
@@ -36,6 +43,10 @@ class SLArLArProperties {
     double fvDriftInverse;       //!< Inverse of drift velocity, for fast computation of drift time
     double fElectronLifetime;    //!< Electron lifetime 
     double fElectronLifetimeInverse; //!< Inverse of electron lifetime, for fast computation of survival fraction
+
+    double fStepThreshold;       //!< Step length threshold for distributing ionization along the step
+    double fLSegment;            //!< Length of segments for distributing ionization along the step
+    unsigned int fNSegmentsLimit;//!< Maximum number of segments for distributing ionization along the step, to avoid excessive segmentation for long steps
 
     double ComputeMobility(double E, double larT);
     double ComputeMobility(std::array<double, 2> par); 

--- a/G4SOLAr/include/physics/SLArElectronDrift.hh
+++ b/G4SOLAr/include/physics/SLArElectronDrift.hh
@@ -10,9 +10,9 @@
 
 #include <math.h>
 #include <vector>
-#include <functional>
 #include "physics/LiquidArgon/SLArLArProperties.hh"
 #include "G4ThreeVector.hh"
+#include "G4SystemOfUnits.hh"
 
 class SLArCfgAnode;
 class SLArEventAnode;
@@ -23,12 +23,17 @@ class SLArElectronDrift {
     ~SLArElectronDrift() {} 
 
     void Drift(const int& n, const int& trkId, const int& ancestorId,
-        const G4ThreeVector& pos, 
-        const double time, 
+        const G4ThreeVector& prestep_pos,
+        const G4ThreeVector& poststep_pos, 
+        const double& prestep_time, 
+        const double& poststep_time,
         SLArCfgAnode* anodeCfg, SLArEventAnode* anodeEv);
 
   private: 
     const SLArLArProperties& fLArProperties;
+    const double fStepThreshold = 1.0*CLHEP::mm; 
+    const double fLSegment = 1.0*CLHEP::mm;
+    const unsigned int fNSegmentsLimit = 100;
 };
 
 

--- a/G4SOLAr/include/physics/SLArElectronDrift.hh
+++ b/G4SOLAr/include/physics/SLArElectronDrift.hh
@@ -31,9 +31,6 @@ class SLArElectronDrift {
 
   private: 
     const SLArLArProperties& fLArProperties;
-    const double fStepThreshold = 1.0*CLHEP::mm; 
-    const double fLSegment = 1.0*CLHEP::mm;
-    const unsigned int fNSegmentsLimit = 100;
 };
 
 

--- a/G4SOLAr/include/physics/SLArPhysicsListMessenger.hh
+++ b/G4SOLAr/include/physics/SLArPhysicsListMessenger.hh
@@ -91,9 +91,6 @@ class SLArPhysicsListMessenger : public G4UImessenger
 
     G4UIcmdWithoutParameter*   fListCMD;
 
-    G4UIcmdWithoutParameter* fPienuCMD;
-    G4UIcmdWithoutParameter* fPimunuCMD;
-
 };
 
 #endif

--- a/G4SOLAr/include/physics/SLArPhysicsListMessenger.hh
+++ b/G4SOLAr/include/physics/SLArPhysicsListMessenger.hh
@@ -72,6 +72,10 @@ class SLArPhysicsListMessenger : public G4UImessenger
 
     G4UIcmdWithABool* fCmdTracePhotons;
     G4UIcmdWithABool* fCmdDriftElectrons;
+    G4UIcmdWithADoubleAndUnit*  fCmdElectronLifetime; 
+    G4UIcmdWithADoubleAndUnit*  fCmdSetLArStepLenThreshold;
+    G4UIcmdWithADoubleAndUnit*  fCmdSetLArSegmentLen;
+    G4UIcmdWithAnInteger*       fCmdSetLArNSegmentsLimit;
 
     G4UIdirectory* fDecayDirectory;
     G4UIcmdWithABool* fSetAbsorptionCMD;

--- a/G4SOLAr/src/analysis/SLArAnalysisManagerMsgr.cc
+++ b/G4SOLAr/src/analysis/SLArAnalysisManagerMsgr.cc
@@ -36,7 +36,6 @@ SLArAnalysisManagerMsgr::SLArAnalysisManagerMsgr() :
   fCmdEnableBacktracker(nullptr),
   fCmdRegisterBacktracker(nullptr), 
   fCmdSetZeroSuppressionThrs(nullptr), 
-  fCmdElectronLifetime(nullptr),
   fCmdXSecEMin(nullptr),
   fCmdXSecEMax(nullptr),
   fCmdXSecNPoints(nullptr),
@@ -119,11 +118,6 @@ SLArAnalysisManagerMsgr::SLArAnalysisManagerMsgr() :
   fCmdSetZeroSuppressionThrs->SetGuidance("Set charge readout zero suppression threshold");
   fCmdSetZeroSuppressionThrs->SetParameterName("threshold", false);
 
-  fCmdElectronLifetime = 
-    new G4UIcmdWithADoubleAndUnit(UIPhysPath+"setElectronLifetime", this); 
-  fCmdElectronLifetime->SetGuidance("Set electrons lifetime in LAr"); 
-  fCmdElectronLifetime->SetParameterName("electron_lifetime", false); 
-  
   fCmdGeoAnodeDepth = 
     new G4UIcmdWithAnInteger(UIGeometryPath+"setAnodeVisDepth", this);
   fCmdGeoAnodeDepth->SetGuidance("Set visualization depth for SoLAr anode");
@@ -193,7 +187,6 @@ SLArAnalysisManagerMsgr::~SLArAnalysisManagerMsgr()
   if (fCmdEnableBacktracker  ) delete fCmdEnableBacktracker  ;
   if (fCmdRegisterBacktracker) delete fCmdRegisterBacktracker;
   if (fCmdSetZeroSuppressionThrs) delete fCmdSetZeroSuppressionThrs;
-  if (fCmdElectronLifetime)    delete fCmdElectronLifetime   ; 
   if (fCmdAddExtScorer       ) delete fCmdAddExtScorer       ; 
   if (fCmdXSecEMin           ) delete fCmdXSecEMin           ;
   if (fCmdXSecEMax           ) delete fCmdXSecEMax           ;
@@ -338,13 +331,6 @@ void SLArAnalysisManagerMsgr::SetNewValue
     }
     return;
   }
-  else if ( cmd == fCmdElectronLifetime ) {
-    auto detector = 
-      (SLArDetectorConstruction*)G4RunManager::GetRunManager()->GetUserDetectorConstruction(); 
-    auto& lar_properties = detector->GetLArProperties(); 
-    lar_properties.SetElectronLifetime( fCmdElectronLifetime->GetNewDoubleValue( newVal ) ); 
-  }
-
   else if (cmd == fCmdSetZeroSuppressionThrs) {
     int thrs = std::atoi( newVal ); 
     for (auto& anode_itr : SLArAnaMgr->GetEventAnode().GetAnodeMap()) {

--- a/G4SOLAr/src/analysis/SensitiveDetectors/SLArLArSD.cc
+++ b/G4SOLAr/src/analysis/SensitiveDetectors/SLArLArSD.cc
@@ -156,7 +156,9 @@ G4bool SLArLArSD::ProcessHits(G4Step* step, G4TouchableHistory*)
       if (physicsList->DoDriftElectrons()) {
         runAction->GetElectronDrift()->Drift(n_el, 
             step->GetTrack()->GetTrackID(), ancestor_id,
-            0.5*(postStepPoint->GetPosition()+preStepPoint->GetPosition()),
+            preStepPoint->GetPosition(),
+            postStepPoint->GetPosition(),
+            preStepPoint->GetGlobalTime(),
             postStepPoint->GetGlobalTime(), 
             &anodeCfg, 
             &anaMngr->GetEventAnode().GetEventAnodeByTPCID(fTPCID)); 

--- a/G4SOLAr/src/physics/LiquidArgon/SLArLArProperties.cc
+++ b/G4SOLAr/src/physics/LiquidArgon/SLArLArProperties.cc
@@ -47,6 +47,14 @@ void SLArLArProperties::ComputeProperties() {
 
   fMuElectron = ComputeMobility(fElectricField, fLArTemperature);
   fvDrift     = ComputeDriftVelocity(fElectricField); 
+  if (fvDrift > 0.0) {
+    fvDriftInverse = 1.0/fvDrift;
+  } else {
+    G4ExceptionDescription ed;
+    ed << "Computed drift velocity is non-positive: " << fvDrift << " cm/ns. Resetting to 0.16 cm/μs.";
+    G4Exception("SLArLArProperties::ComputeProperties", "InvalidDriftVelocity", JustWarning, ed);
+    fvDrift = 0.16*CLHEP::cm/CLHEP::microsecond;
+  }
   fvDriftInverse = 1.0/fvDrift;
   auto diff   = ComputeDiffusion(fElectricField, fLArTemperature); 
   fDiffCoefficientL = diff.at(0); 

--- a/G4SOLAr/src/physics/LiquidArgon/SLArLArProperties.cc
+++ b/G4SOLAr/src/physics/LiquidArgon/SLArLArProperties.cc
@@ -10,14 +10,16 @@
 SLArLArProperties::SLArLArProperties() :
   fElectricField(0.5), fLArTemperature(87.7), fMuElectron(1.), 
   fDiffCoefficientL(0.), fDiffCoefficientT(0.), 
-  fvDrift(1.0), fvDriftInverse(1.0), fElectronLifetime(1e7), fElectronLifetimeInverse(1e-7)
+  fvDrift(1.0), fvDriftInverse(1.0), fElectronLifetime(1e7), fElectronLifetimeInverse(1e-7), 
+  fStepThreshold(2.0*CLHEP::mm), fLSegment(0.5*CLHEP::mm), fNSegmentsLimit(100)
 {}
 
 SLArLArProperties::SLArLArProperties(const SLArLArProperties& p) :
   fElectricField(p.fElectricField), fLArTemperature(p.fLArTemperature), fMuElectron(p.fMuElectron), 
   fDiffCoefficientL(p.fDiffCoefficientL), fDiffCoefficientT(p.fDiffCoefficientT), 
   fvDrift(p.fvDrift), fvDriftInverse(p.fvDriftInverse), 
-  fElectronLifetime(p.fElectronLifetime), fElectronLifetimeInverse(p.fElectronLifetimeInverse)
+  fElectronLifetime(p.fElectronLifetime), fElectronLifetimeInverse(p.fElectronLifetimeInverse),
+  fStepThreshold(p.fStepThreshold), fLSegment(p.fLSegment), fNSegmentsLimit(p.fNSegmentsLimit)
 {}
 
 SLArLArProperties& SLArLArProperties::operator=(const SLArLArProperties& p) {
@@ -31,6 +33,9 @@ SLArLArProperties& SLArLArProperties::operator=(const SLArLArProperties& p) {
     fvDriftInverse = p.fvDriftInverse;
     fElectronLifetime = p.fElectronLifetime;
     fElectronLifetimeInverse = p.fElectronLifetimeInverse;
+    fStepThreshold = p.fStepThreshold;
+    fLSegment = p.fLSegment;
+    fNSegmentsLimit = p.fNSegmentsLimit;
   }
 
   return *this;
@@ -106,6 +111,9 @@ void SLArLArProperties::PrintProperties() const {
   printf("* drift velocity: %g cm/μs\n", fvDrift * 1e+2);
   printf("* diff coeff L: %g cm²/s\n", fDiffCoefficientL*1e+7);
   printf("* diff coeff T: %g cm²/s\n", fDiffCoefficientT*1e+7);
+  printf("* step length threshold: %g mm\n", fStepThreshold / CLHEP::mm);
+  printf("* segment length: %g mm\n", fLSegment / CLHEP::mm);
+  printf("* max number of segments: %u\n", fNSegmentsLimit);
   printf("**************************************************\n");
   return;
 }

--- a/G4SOLAr/src/physics/LiquidArgon/SLArLArProperties.cc
+++ b/G4SOLAr/src/physics/LiquidArgon/SLArLArProperties.cc
@@ -10,13 +10,14 @@
 SLArLArProperties::SLArLArProperties() :
   fElectricField(0.5), fLArTemperature(87.7), fMuElectron(1.), 
   fDiffCoefficientL(0.), fDiffCoefficientT(0.), 
-  fvDrift(1.0), fElectronLifetime(1e7)
+  fvDrift(1.0), fvDriftInverse(1.0), fElectronLifetime(1e7), fElectronLifetimeInverse(1e-7)
 {}
 
 SLArLArProperties::SLArLArProperties(const SLArLArProperties& p) :
   fElectricField(p.fElectricField), fLArTemperature(p.fLArTemperature), fMuElectron(p.fMuElectron), 
   fDiffCoefficientL(p.fDiffCoefficientL), fDiffCoefficientT(p.fDiffCoefficientT), 
-  fvDrift(p.fvDrift), fElectronLifetime(p.fElectronLifetime)
+  fvDrift(p.fvDrift), fvDriftInverse(p.fvDriftInverse), 
+  fElectronLifetime(p.fElectronLifetime), fElectronLifetimeInverse(p.fElectronLifetimeInverse)
 {}
 
 SLArLArProperties& SLArLArProperties::operator=(const SLArLArProperties& p) {
@@ -27,7 +28,9 @@ SLArLArProperties& SLArLArProperties::operator=(const SLArLArProperties& p) {
     fDiffCoefficientL = p.fDiffCoefficientL;
     fDiffCoefficientT = p.fDiffCoefficientT;
     fvDrift = p.fvDrift;
+    fvDriftInverse = p.fvDriftInverse;
     fElectronLifetime = p.fElectronLifetime;
+    fElectronLifetimeInverse = p.fElectronLifetimeInverse;
   }
 
   return *this;
@@ -39,6 +42,7 @@ void SLArLArProperties::ComputeProperties() {
 
   fMuElectron = ComputeMobility(fElectricField, fLArTemperature);
   fvDrift     = ComputeDriftVelocity(fElectricField); 
+  fvDriftInverse = 1.0/fvDrift;
   auto diff   = ComputeDiffusion(fElectricField, fLArTemperature); 
   fDiffCoefficientL = diff.at(0); 
   fDiffCoefficientT = diff.at(1); 

--- a/G4SOLAr/src/physics/SLArElectronDrift.cc
+++ b/G4SOLAr/src/physics/SLArElectronDrift.cc
@@ -50,9 +50,9 @@ void SLArElectronDrift::Drift(const int& n,
   double dt_step = poststep_time - prestep_time;
 
   unsigned int nSegments = 1; 
-  if (stepLen > fStepThreshold) {
-    nSegments = static_cast<unsigned int>(std::ceil(stepLen/fLSegment));
-    if (nSegments > fNSegmentsLimit) nSegments = fNSegmentsLimit;
+  if (stepLen > fLArProperties.fStepThreshold) {
+    nSegments = static_cast<unsigned int>(std::ceil(stepLen/fLArProperties.fLSegment));
+    if (nSegments > fLArProperties.fNSegmentsLimit) nSegments = fLArProperties.fNSegmentsLimit;
   }
 
   const int n_per_segment = static_cast<int>( n / nSegments );

--- a/G4SOLAr/src/physics/SLArElectronDrift.cc
+++ b/G4SOLAr/src/physics/SLArElectronDrift.cc
@@ -22,15 +22,19 @@ SLArElectronDrift::SLArElectronDrift(const SLArLArProperties& lar_properties) : 
 void SLArElectronDrift::Drift(const int& n, 
     const int& trkId,
     const int& ancestorId,
-    const G4ThreeVector& pos, 
-    const double time, 
+    const G4ThreeVector& prePos, 
+    const G4ThreeVector& postPos, 
+    const double& prestep_time, 
+    const double& poststep_time,
     SLArCfgAnode* anodeCfg, 
     SLArEventAnode* anodeEv) 
 {
-  auto ana_mngr = SLArAnalysisManager::Instance();
-  auto bkt_mngr = ana_mngr->GetBacktrackerManager( backtracker:: kCharge );
+  if (n <= 0) return;
 
-  // Find the megatile interested by the hit
+  auto ana_mngr = SLArAnalysisManager::Instance();
+  auto bkt_mngr = ana_mngr->GetBacktrackerManager( backtracker::kCharge );
+
+  // Build anode reference frame
   G4ThreeVector anodeXaxis = 
     G4ThreeVector(anodeCfg->GetAxis0().x(), anodeCfg->GetAxis0().y(), anodeCfg->GetAxis0().z());
   G4ThreeVector anodeYaxis = 
@@ -40,66 +44,94 @@ void SLArElectronDrift::Drift(const int& n,
   G4ThreeVector anodePos = 
     G4ThreeVector(anodeCfg->GetPhysX(), anodeCfg->GetPhysY(), anodeCfg->GetPhysZ()); 
 
-  // Get anode position and compute drift time
-  G4ThreeVector pos_local = (pos - anodePos);
-  G4double driftLength = pos_local.dot(anodeNormal);
-  if (driftLength < 0) return;
+  // Step assessment 
+  G4ThreeVector stepVec = postPos - prePos;
+  double stepLen = stepVec.mag();
+  double dt_step = poststep_time - prestep_time;
 
-  G4double driftTime   = driftLength / fLArProperties.fvDrift;
-  G4double hitTime     = time + driftTime; 
-  // compute diffusion length and fraction of surviving electrons
-  G4double diffLengthT = sqrt(2*fLArProperties.fDiffCoefficientT*driftTime); 
-  G4double diffLengthL = sqrt(2*fLArProperties.fDiffCoefficientL*driftTime); 
-  G4double f_surv      = exp (-driftTime/fLArProperties.fElectronLifetime); 
+  unsigned int nSegments = 1; 
+  if (stepLen > fStepThreshold) {
+    nSegments = static_cast<unsigned int>(std::ceil(stepLen/fLSegment));
+    if (nSegments > fNSegmentsLimit) nSegments = fNSegmentsLimit;
+  }
+
+  const int n_per_segment = static_cast<int>( n / nSegments );
+  const int n_remaining = static_cast<int>(n % nSegments);
+
+  for (unsigned int iseg =0; iseg < nSegments; iseg++) {
+
+    int n_elec_segment = n_per_segment + (iseg < n_remaining ? 1 : 0);
+    if (n_elec_segment == 0) continue;
+
+    // Compute segment position and time
+    double u = (iseg + 0.5) / nSegments;
+    G4ThreeVector pos = prePos + u*stepVec;
+    double time = prestep_time + u*dt_step;
+
+    // Get anode position and compute drift time
+    G4ThreeVector pos_local = (pos - anodePos);
+    G4double driftLength = pos_local.dot(anodeNormal);
+    if (driftLength < 0) return;
+
+    G4double driftTime   = driftLength * fLArProperties.fvDriftInverse;
+    G4double hitTime     = time + driftTime; 
+    // compute diffusion length and fraction of surviving electrons
+    G4double diffLengthT = sqrt(2*fLArProperties.fDiffCoefficientT*driftTime); 
+    G4double diffLengthL = sqrt(2*fLArProperties.fDiffCoefficientL*driftTime); 
+
+    G4double f_surv      = exp (-driftTime * fLArProperties.fElectronLifetimeInverse); 
 
 #ifdef SLAR_DEBUG
-  printf("%i electrons at [%.0f, %0.f, %0.f] mm, t = %g ns\n", 
-      n, pos.x(), pos.y(), pos.z(), time);
-  printf("local_coordinates: [%.0f, %.0f, %.0f] mm\n", pos_local.x(), pos_local.y(), pos_local.z());
-  printf("axis projection: [%.0f, %.0f]\n", pos_local.dot(anodeXaxis), pos_local.dot(anodeYaxis)); 
-  printf("Drift len = %g mm, time: %g ns, f_surv = %.2f%% - σ(L) = %g mm, σ(T) = %g mm\n", 
-  driftLength, driftTime, f_surv*100, diffLengthL, diffLengthT);
-  getchar(); 
+    printf("%i electrons at [%.0f, %0.f, %0.f] mm, t = %g ns\n", 
+        n, pos.x(), pos.y(), pos.z(), time);
+    printf("local_coordinates: [%.0f, %.0f, %.0f] mm\n", pos_local.x(), pos_local.y(), pos_local.z());
+    printf("axis projection: [%.0f, %.0f]\n", pos_local.dot(anodeXaxis), pos_local.dot(anodeYaxis)); 
+    printf("Drift len = %g mm, time: %g ns, f_surv = %.2f%% - σ(L) = %g mm, σ(T) = %g mm\n", 
+        driftLength, driftTime, f_surv*100, diffLengthL, diffLengthT);
+    getchar(); 
 #endif
 
-  G4int n_elec_anode = G4Poisson(n*f_surv); 
+    G4int n_elec_anode = G4Poisson(n_elec_segment*f_surv); 
   
-  if (n_elec_anode == 0) {
-    return;
-  }
-  std::vector<double> x_(n_elec_anode); 
-  std::vector<double> y_(n_elec_anode); 
-  std::vector<double> t_(n_elec_anode);
-  G4RandGauss::shootArray(n_elec_anode, &x_[0], pos_local.dot(anodeXaxis), diffLengthT); 
-  G4RandGauss::shootArray(n_elec_anode, &y_[0], pos_local.dot(anodeYaxis), diffLengthT); 
-  G4RandGauss::shootArray(n_elec_anode, &t_[0], hitTime, diffLengthL / fLArProperties.fvDrift); 
+    if (n_elec_anode == 0) continue;
+    
+    std::vector<double> x_(n_elec_anode); 
+    std::vector<double> y_(n_elec_anode); 
+    std::vector<double> t_(n_elec_anode);
+    G4double posX = pos_local.dot(anodeXaxis);
+    G4double posY = pos_local.dot(anodeYaxis);
+    G4RandGauss::shootArray(n_elec_anode, &x_[0], posX, diffLengthT); 
+    G4RandGauss::shootArray(n_elec_anode, &y_[0], posY, diffLengthT); 
+    G4RandGauss::shootArray(n_elec_anode, &t_[0], hitTime, diffLengthL * fLArProperties.fvDriftInverse); 
 
-  SLArCfgAnode::SLArPixIdx pixID;
-  for (G4int i=0; i<n_elec_anode; i++) {
-    pixID = anodeCfg->GetPixelIndex(x_[i], y_[i]); 
-    //printf("pixID: %i, %i, %i\n", pixID[0], pixID[1], pixID[2]);
-    if (pixID[0] >= 0 && pixID[1] >= 0 && pixID[2] >= 0 ) {
+    // Register hits on anode
+    SLArCfgAnode::SLArPixIdx pixID;
+    for (G4int i=0; i<n_elec_anode; i++) {
+      pixID = anodeCfg->GetPixelIndex(x_[i], y_[i]); 
+      //printf("pixID: %i, %i, %i\n", pixID[0], pixID[1], pixID[2]);
+      if (pixID[0] >= 0 && pixID[1] >= 0 && pixID[2] >= 0 ) {
 
-      SLArEventChargeHit hit(t_[i], trkId, ancestorId); 
-      auto& evPixel = anodeEv->RegisterChargeHit(pixID, hit); 
+        SLArEventChargeHit hit(t_[i], trkId, ancestorId); 
+        auto& evPixel = anodeEv->RegisterChargeHit(pixID, hit); 
 
-      //#ifdef SLAR_DEBUG
-      //printf("\tdiff x,y: %.2f - %.2f mm\n", x_[i], y_[i]);
-      //printf("\tpix id: %i, %i, %i\n", pixID[0], pixID[1], pixID[2]);
-      ////evT->PrintHits(); 
-      //getchar();
-      //#endif
+        //#ifdef SLAR_DEBUG
+        //printf("\tdiff x,y: %.2f - %.2f mm\n", x_[i], y_[i]);
+        //printf("\tpix id: %i, %i, %i\n", pixID[0], pixID[1], pixID[2]);
+        ////evT->PrintHits(); 
+        //getchar();
+        //#endif
 
-      if (bkt_mngr == nullptr) continue;
+        if (bkt_mngr == nullptr) continue;
 
-      if (bkt_mngr->IsNull()) continue;
+        if (bkt_mngr->IsNull()) continue;
 
-      auto& records = 
-        evPixel.GetBacktrackerVector( evPixel.ConvertToClock<float>(hit.GetTime()));
+        auto& records = 
+          evPixel.GetBacktrackerVector( evPixel.ConvertToClock<float>(hit.GetTime()));
 
-      for (size_t ib = 0; ib < bkt_mngr->GetBacktrackers().size(); ib++) {
-        bkt_mngr->GetBacktrackers().at(ib)->Eval(&hit, 
-            &records.GetRecords().at(ib));
+        for (size_t ib = 0; ib < bkt_mngr->GetBacktrackers().size(); ib++) {
+          bkt_mngr->GetBacktrackers().at(ib)->Eval(&hit, 
+              &records.GetRecords().at(ib));
+        }
       }
     }
   }

--- a/G4SOLAr/src/physics/SLArElectronDrift.cc
+++ b/G4SOLAr/src/physics/SLArElectronDrift.cc
@@ -4,8 +4,9 @@
  * @created     Thur Nov 10, 2022 18:26:54 CET
  */
 
+#include <cmath>
+
 #include "physics/SLArElectronDrift.hh"
-#include <functional>
 #include "SLArAnalysisManager.hh"
 #include "SLArBacktrackerManager.hh"
 #include "event/SLArEventAnode.hh"
@@ -71,7 +72,7 @@ void SLArElectronDrift::Drift(const int& n,
     // Get anode position and compute drift time
     G4ThreeVector pos_local = (pos - anodePos);
     G4double driftLength = pos_local.dot(anodeNormal);
-    if (driftLength < 0) return;
+    if (driftLength < 0) continue;
 
     G4double driftTime   = driftLength * fLArProperties.fvDriftInverse;
     G4double hitTime     = time + driftTime; 

--- a/G4SOLAr/src/physics/SLArPhysicsListMessenger.cc
+++ b/G4SOLAr/src/physics/SLArPhysicsListMessenger.cc
@@ -31,8 +31,9 @@
 //
 #include "globals.hh"
 
-#include "SLArPhysicsListMessenger.hh"
-#include "SLArPhysicsList.hh"
+#include "physics/SLArPhysicsListMessenger.hh"
+#include "physics/SLArPhysicsList.hh"
+#include "geo/detector/SLArDetectorConstruction.hh"
 
 #include "G4UIdirectory.hh"
 #include "G4UIcmdWithABool.hh"
@@ -62,6 +63,26 @@ SLArPhysicsListMessenger::SLArPhysicsListMessenger(SLArPhysicsList* pPhys)
   fCmdDriftElectrons->SetParameterName("do_trace", false, true); 
   fCmdDriftElectrons->SetDefaultValue(true);
 
+  fCmdElectronLifetime = 
+    new G4UIcmdWithADoubleAndUnit("/SLAr/phys/setElectronLifetime", this); 
+  fCmdElectronLifetime->SetGuidance("Set electrons lifetime in LAr"); 
+  fCmdElectronLifetime->SetParameterName("electron_lifetime", false); 
+
+  fCmdSetLArStepLenThreshold = 
+    new G4UIcmdWithADoubleAndUnit("/SLAr/phys/setLArStepLenThreshold", this);
+  fCmdSetLArStepLenThreshold->SetGuidance("Set step length threshold for distributing ionization along the step");
+  fCmdSetLArStepLenThreshold->SetParameterName("step_length_threshold", false);
+
+  fCmdSetLArSegmentLen = 
+    new G4UIcmdWithADoubleAndUnit("/SLAr/phys/setLArSegmentLen", this);
+  fCmdSetLArSegmentLen->SetGuidance("Set length of segments for distributing ionization along the step");
+  fCmdSetLArSegmentLen->SetParameterName("segment_length", false);
+
+  fCmdSetLArNSegmentsLimit = 
+    new G4UIcmdWithAnInteger("/SLAr/phys/setLArNSegmentsLimit", this);
+  fCmdSetLArNSegmentsLimit->SetGuidance("Set max number of segments for distributing ionization along the step, to avoid excessive segmentation for long steps");
+  fCmdSetLArNSegmentsLimit->SetParameterName("n_segments_limit", false);
+  
   fSetAbsorptionCMD = new G4UIcmdWithABool(
       "/SLAr/phys/setAbsorption", this);
   fSetAbsorptionCMD->SetGuidance("Turn on or off absorption process");
@@ -161,6 +182,10 @@ SLArPhysicsListMessenger::~SLArPhysicsListMessenger()
 {
   delete fCmdTracePhotons;
   delete fCmdDriftElectrons;
+  delete fCmdElectronLifetime; 
+  delete fCmdSetLArStepLenThreshold;
+  delete fCmdSetLArSegmentLen;
+  delete fCmdSetLArNSegmentsLimit;
 
   delete fVerboseCmd;
   delete fCerenkovCmd;
@@ -194,6 +219,30 @@ void SLArPhysicsListMessenger::SetNewValue(G4UIcommand* command,
   else if (command == fCmdDriftElectrons) {
     bool do_drift = fCmdDriftElectrons->GetNewBoolValue(newValue); 
     fPhysicsList->SetDriftElectrons(do_drift); 
+  }
+  else if (command == fCmdElectronLifetime ) {
+    auto detector = 
+      (SLArDetectorConstruction*)G4RunManager::GetRunManager()->GetUserDetectorConstruction(); 
+    auto& lar_properties = detector->GetLArProperties(); 
+    lar_properties.SetElectronLifetime( fCmdElectronLifetime->GetNewDoubleValue( newValue ) ); 
+  }
+  else if (command == fCmdSetLArStepLenThreshold) {
+    auto detector = 
+      (SLArDetectorConstruction*)G4RunManager::GetRunManager()->GetUserDetectorConstruction(); 
+    auto& lar_properties = detector->GetLArProperties(); 
+    lar_properties.SetStepLengthThreshold( fCmdSetLArStepLenThreshold->GetNewDoubleValue( newValue ) );
+  }
+  else if (command == fCmdSetLArSegmentLen) {
+    auto detector = 
+      (SLArDetectorConstruction*)G4RunManager::GetRunManager()->GetUserDetectorConstruction(); 
+    auto& lar_properties = detector->GetLArProperties(); 
+    lar_properties.SetSegmentLength( fCmdSetLArSegmentLen->GetNewDoubleValue( newValue ) );
+  }
+  else if (command == fCmdSetLArNSegmentsLimit) {
+    auto detector = 
+      (SLArDetectorConstruction*)G4RunManager::GetRunManager()->GetUserDetectorConstruction(); 
+    auto& lar_properties = detector->GetLArProperties(); 
+    lar_properties.SetNSegmentsLimit( fCmdSetLArNSegmentsLimit->GetNewIntValue( newValue ) );
   }
   else if( command == fSetAbsorptionCMD ) {
     fPhysicsList->SetAbsorption(G4UIcmdWithABool::GetNewBoolValue(newValue));

--- a/G4SOLAr/src/physics/SLArPhysicsListMessenger.cc
+++ b/G4SOLAr/src/physics/SLArPhysicsListMessenger.cc
@@ -41,10 +41,6 @@
 #include "G4UIcmdWithoutParameter.hh"
 #include "G4UIcmdWithADoubleAndUnit.hh"
 
-#include "G4PhaseSpaceDecayChannel.hh"
-#include "G4ProcessTable.hh"
-#include "G4PionRadiativeDecayChannel.hh"
-
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 SLArPhysicsListMessenger::SLArPhysicsListMessenger(SLArPhysicsList* pPhys)
@@ -157,12 +153,6 @@ SLArPhysicsListMessenger::SLArPhysicsListMessenger(SLArPhysicsList* pPhys)
   fDecayDirectory = new G4UIdirectory("/decay/");
   fDecayDirectory->SetGuidance("Decay chain control commands.");
 
-  fPienuCMD = new G4UIcmdWithoutParameter("/decay/pienu", this);
-  fPienuCMD->SetGuidance("Sets the pi+ to decay into e+, nu");
-
-  fPimunuCMD = new G4UIcmdWithoutParameter("/decay/pimunu", this);
-  fPimunuCMD->SetGuidance("Sets the pi+ to decay into mu+, nu");
-
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -188,9 +178,6 @@ SLArPhysicsListMessenger::~SLArPhysicsListMessenger()
   delete fRemovePhysicsCMD;
 
   delete fListCMD;
-
-  delete fPienuCMD;
-  delete fPimunuCMD;
 
   delete fDirectory;
 }
@@ -219,28 +206,6 @@ void SLArPhysicsListMessenger::SetNewValue(G4UIcommand* command,
   else if( command == fCerenkovCmd ) {
     fPhysicsList->
       SetNbOfPhotonsCerenkov(fCerenkovCmd->GetNewIntValue(newValue));
-  }
-
-  else if (command == fPienuCMD) {
-    G4ParticleTable* particleTable = G4ParticleTable::GetParticleTable();
-    G4ParticleDefinition* particleDef = particleTable->FindParticle("pi+");
-    G4VDecayChannel* mode = 
-      new G4PhaseSpaceDecayChannel("pi+",1.0,2,"e+","nu_e");
-    G4DecayTable* table = new G4DecayTable();
-    table->Insert(mode);
-    // mode = new G4PionRadiativeDecayChannel("pi+",0.000017);
-    // table->Insert(mode);
-    particleDef->SetDecayTable(table);
-  }
-
-  else if (command == fPimunuCMD) {
-    G4ParticleTable* particleTable = G4ParticleTable::GetParticleTable();
-    G4ParticleDefinition* particleDef = particleTable->FindParticle("pi+");
-    G4VDecayChannel* mode =
-      new G4PhaseSpaceDecayChannel("pi+",1.000,2,"mu+","nu_mu");
-    G4DecayTable* table = new G4DecayTable();
-    table->Insert(mode);
-    particleDef->SetDecayTable(table);
   }
 
   else if (command == fGammaCutCMD) {

--- a/G4SOLAr/src/physics/SLArPhysicsListMessenger.cc
+++ b/G4SOLAr/src/physics/SLArPhysicsListMessenger.cc
@@ -35,6 +35,7 @@
 #include "physics/SLArPhysicsList.hh"
 #include "geo/detector/SLArDetectorConstruction.hh"
 
+#include "G4RunManager.hh"
 #include "G4UIdirectory.hh"
 #include "G4UIcmdWithABool.hh"
 #include "G4UIcmdWithAString.hh"
@@ -67,21 +68,28 @@ SLArPhysicsListMessenger::SLArPhysicsListMessenger(SLArPhysicsList* pPhys)
     new G4UIcmdWithADoubleAndUnit("/SLAr/phys/setElectronLifetime", this); 
   fCmdElectronLifetime->SetGuidance("Set electrons lifetime in LAr"); 
   fCmdElectronLifetime->SetParameterName("electron_lifetime", false); 
+  fCmdElectronLifetime->SetUnitCategory("Time");
+  fCmdElectronLifetime->SetRange("electron_lifetime>0.0");
 
   fCmdSetLArStepLenThreshold = 
     new G4UIcmdWithADoubleAndUnit("/SLAr/phys/setLArStepLenThreshold", this);
   fCmdSetLArStepLenThreshold->SetGuidance("Set step length threshold for distributing ionization along the step");
   fCmdSetLArStepLenThreshold->SetParameterName("step_length_threshold", false);
+  fCmdSetLArStepLenThreshold->SetUnitCategory("Length");
+  fCmdSetLArStepLenThreshold->SetRange("step_length_threshold>0.0");
 
   fCmdSetLArSegmentLen = 
     new G4UIcmdWithADoubleAndUnit("/SLAr/phys/setLArSegmentLen", this);
   fCmdSetLArSegmentLen->SetGuidance("Set length of segments for distributing ionization along the step");
   fCmdSetLArSegmentLen->SetParameterName("segment_length", false);
+  fCmdSetLArSegmentLen->SetUnitCategory("Length");
+  fCmdSetLArSegmentLen->SetRange("segment_length>0.0");
 
   fCmdSetLArNSegmentsLimit = 
     new G4UIcmdWithAnInteger("/SLAr/phys/setLArNSegmentsLimit", this);
   fCmdSetLArNSegmentsLimit->SetGuidance("Set max number of segments for distributing ionization along the step, to avoid excessive segmentation for long steps");
   fCmdSetLArNSegmentsLimit->SetParameterName("n_segments_limit", false);
+  fCmdSetLArNSegmentsLimit->SetRange("n_segments_limit>1");
   
   fSetAbsorptionCMD = new G4UIcmdWithABool(
       "/SLAr/phys/setAbsorption", this);
@@ -170,10 +178,6 @@ SLArPhysicsListMessenger::SLArPhysicsListMessenger(SLArPhysicsList* pPhys)
   fListCMD = new G4UIcmdWithoutParameter("/SLAr/phys/list",this);
   fListCMD->SetGuidance("Available Physics Lists");
   fListCMD->AvailableForStates(G4State_Idle);
-
-  fDecayDirectory = new G4UIdirectory("/decay/");
-  fDecayDirectory->SetGuidance("Decay chain control commands.");
-
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -203,7 +207,6 @@ SLArPhysicsListMessenger::~SLArPhysicsListMessenger()
   delete fRemovePhysicsCMD;
 
   delete fListCMD;
-
   delete fDirectory;
 }
 
@@ -242,7 +245,14 @@ void SLArPhysicsListMessenger::SetNewValue(G4UIcommand* command,
     auto detector = 
       (SLArDetectorConstruction*)G4RunManager::GetRunManager()->GetUserDetectorConstruction(); 
     auto& lar_properties = detector->GetLArProperties(); 
-    lar_properties.SetNSegmentsLimit( fCmdSetLArNSegmentsLimit->GetNewIntValue( newValue ) );
+    G4int nSegmentsLimit = fCmdSetLArNSegmentsLimit->GetNewIntValue( newValue );
+    if (nSegmentsLimit < 1) {
+      G4ExceptionDescription ed;
+      ed << "Invalid number of segments limit: " << nSegmentsLimit << ". Resetting to 1.";;
+      G4Exception("SLArPhysicsListMessenger::SetNewValue", "InvalidSegmentLimit", JustWarning, ed);
+      nSegmentsLimit = 1;
+    }
+    lar_properties.SetNSegmentsLimit( nSegmentsLimit );
   }
   else if( command == fSetAbsorptionCMD ) {
     fPhysicsList->SetAbsorption(G4UIcmdWithABool::GetNewBoolValue(newValue));


### PR DESCRIPTION
This pull request refactors and extends the configuration and handling of electron drift and ionization segmentation in the liquid argon detector simulation. The main improvements include a more flexible and physically accurate segmentation of ionization along particle steps, the addition of new user interface commands for configuring segmentation parameters, and the relocation of certain configuration responsibilities from the analysis manager to the physics list messenger. Additionally, internal optimizations were made for faster computation by caching inverse values.

The most important changes are:

**1. Electron drift and ionization segmentation improvements**
- The `SLArElectronDrift::Drift` method now segments steps longer than a configurable threshold into multiple sub-segments, distributing electrons accordingly. This enables more accurate modeling of ionization along the track and prevents excessive segmentation by capping the number of segments. The drift and survival calculations now use cached inverse values for performance. (`G4SOLAr/src/physics/SLArElectronDrift.cc` [[1]](diffhunk://#diff-da717c17e4cd146f68fa70d0dcfb344b51c15f65db7dde70f672cd531bad6ef4L25-R37) [[2]](diffhunk://#diff-da717c17e4cd146f68fa70d0dcfb344b51c15f65db7dde70f672cd531bad6ef4R47-R82) [[3]](diffhunk://#diff-da717c17e4cd146f68fa70d0dcfb344b51c15f65db7dde70f672cd531bad6ef4L65-R107) [[4]](diffhunk://#diff-da717c17e4cd146f68fa70d0dcfb344b51c15f65db7dde70f672cd531bad6ef4R138); `G4SOLAr/include/physics/SLArElectronDrift.hh` [[5]](diffhunk://#diff-b398ad4f7fb079a1309438cbd09ee67644190f6666de66cde3befe862a4b8f81L26-R29)

**2. New configuration parameters for segmentation**
- Added new parameters (`fStepThreshold`, `fLSegment`, `fNSegmentsLimit`) to `SLArLArProperties` for controlling step segmentation, with corresponding getters and setters. These are initialized with sensible defaults and are now printed in the property summary. (`G4SOLAr/include/physics/LiquidArgon/SLArLArProperties.hh` [[1]](diffhunk://#diff-76b648ceeb71bf122ae54322a464f65d41020c0405f76f92164ec8e312f34900R23-L25) [[2]](diffhunk://#diff-76b648ceeb71bf122ae54322a464f65d41020c0405f76f92164ec8e312f34900R43-R49); `G4SOLAr/src/physics/LiquidArgon/SLArLArProperties.cc` [[3]](diffhunk://#diff-8d2d246a22c15e7c5f64fe24b7868a3c647ba7164693fb554f7b59f86ef75b11L13-R22) [[4]](diffhunk://#diff-8d2d246a22c15e7c5f64fe24b7868a3c647ba7164693fb554f7b59f86ef75b11R33-R38) [[5]](diffhunk://#diff-8d2d246a22c15e7c5f64fe24b7868a3c647ba7164693fb554f7b59f86ef75b11R50) [[6]](diffhunk://#diff-8d2d246a22c15e7c5f64fe24b7868a3c647ba7164693fb554f7b59f86ef75b11R114-R116)

**3. User interface and configuration refactoring**
- Removed the electron lifetime command from the analysis manager messenger (`SLArAnalysisManagerMsgr`) and moved it, along with new segmentation-related commands, to the physics list messenger (`SLArPhysicsListMessenger`). This centralizes physics configuration and makes segmentation parameters user-configurable via UI commands. (`G4SOLAr/include/analysis/SLArAnalysisManagerMsgr.hh` [[1]](diffhunk://#diff-ec7381cc8fc59655e1baee4390b2ee5a1de968ba9a5297ae29edc06598d1668eL58); `G4SOLAr/src/analysis/SLArAnalysisManagerMsgr.cc` [[2]](diffhunk://#diff-4ff368b5d9bc9235752a512b8aad7315c9880dde6a38d92e4a01e7911502c37dL39) [[3]](diffhunk://#diff-4ff368b5d9bc9235752a512b8aad7315c9880dde6a38d92e4a01e7911502c37dL122-L126) [[4]](diffhunk://#diff-4ff368b5d9bc9235752a512b8aad7315c9880dde6a38d92e4a01e7911502c37dL196) [[5]](diffhunk://#diff-4ff368b5d9bc9235752a512b8aad7315c9880dde6a38d92e4a01e7911502c37dL341-L347); `G4SOLAr/include/physics/SLArPhysicsListMessenger.hh` [[6]](diffhunk://#diff-4157604ceb1b06d100d1b636daffe8005164a48284b448033e7e8abb45727df5R75-R78) [[7]](diffhunk://#diff-4157604ceb1b06d100d1b636daffe8005164a48284b448033e7e8abb45727df5L94-L96); `G4SOLAr/src/physics/SLArPhysicsListMessenger.cc` [[8]](diffhunk://#diff-c3d38e1db56dd86be64a91e6850160a4ab32f9e0121dd5d796384e2e25183092L34-R36) [[9]](diffhunk://#diff-c3d38e1db56dd86be64a91e6850160a4ab32f9e0121dd5d796384e2e25183092L44-L47) [[10]](diffhunk://#diff-c3d38e1db56dd86be64a91e6850160a4ab32f9e0121dd5d796384e2e25183092R66-R85) [[11]](diffhunk://#diff-c3d38e1db56dd86be64a91e6850160a4ab32f9e0121dd5d796384e2e25183092L160-L165) [[12]](diffhunk://#diff-c3d38e1db56dd86be64a91e6850160a4ab32f9e0121dd5d796384e2e25183092R185-R188) [[13]](diffhunk://#diff-c3d38e1db56dd86be64a91e6850160a4ab32f9e0121dd5d796384e2e25183092L192-L194)

**4. Minor code and interface cleanups**
- Removed unused commands and includes, and updated code to use new parameter names and structures where appropriate. (`G4SOLAr/include/physics/SLArPhysicsListMessenger.hh` [[1]](diffhunk://#diff-4157604ceb1b06d100d1b636daffe8005164a48284b448033e7e8abb45727df5L94-L96); `G4SOLAr/src/physics/SLArPhysicsListMessenger.cc` [[2]](diffhunk://#diff-c3d38e1db56dd86be64a91e6850160a4ab32f9e0121dd5d796384e2e25183092L44-L47) [[3]](diffhunk://#diff-c3d38e1db56dd86be64a91e6850160a4ab32f9e0121dd5d796384e2e25183092L160-L165) [[4]](diffhunk://#diff-c3d38e1db56dd86be64a91e6850160a4ab32f9e0121dd5d796384e2e25183092L192-L194); `G4SOLAr/include/physics/SLArElectronDrift.hh` [[5]](diffhunk://#diff-b398ad4f7fb079a1309438cbd09ee67644190f6666de66cde3befe862a4b8f81L13-R15)

**5. Propagation of interface changes**
- Updated sensitive detector and drift method calls to use the new segmented interface, passing both pre- and post-step positions and times. (`G4SOLAr/src/analysis/SensitiveDetectors/SLArLArSD.cc` [[1]](diffhunk://#diff-7558442d876f34074183560aaa2ddeea5a8bd13bc6a08c5cf8c3bbb3e9a3fad0L159-R161); `G4SOLAr/include/physics/SLArElectronDrift.hh` [[2]](diffhunk://#diff-b398ad4f7fb079a1309438cbd09ee67644190f6666de66cde3befe862a4b8f81L26-R29)

These changes collectively make the simulation more flexible, accurate, and maintainable, especially for studies sensitive to the details of ionization and electron drift in liquid argon.